### PR TITLE
Update capacoa-artsdata-usermeta.php for bios

### DIFF
--- a/capacoa-artsdata-usermeta.php
+++ b/capacoa-artsdata-usermeta.php
@@ -55,6 +55,8 @@ function get_user_meta_for_restapi($user, $field_name, $request) {
 		'pmpro_approval_12' => $userObj->pmpro_approval_12,
 		'pmpro_approval_13' => $userObj->pmpro_approval_13,
 	    	'description' => $userObj->description,
+	    	'description_fr' => $userObj->description_fr,
+	    	'MemberTerminationDate' => $userObj->MemberTerminationDate,
     );
 }
 

--- a/capacoa-artsdata-usermeta.php
+++ b/capacoa-artsdata-usermeta.php
@@ -54,6 +54,7 @@ function get_user_meta_for_restapi($user, $field_name, $request) {
 		'pmpro_bstate' => $userObj->pmpro_bstate,
 		'pmpro_approval_12' => $userObj->pmpro_approval_12,
 		'pmpro_approval_13' => $userObj->pmpro_approval_13,
+	    	'description' => $userObj->description,
     );
 }
 


### PR DESCRIPTION
The default "Biographical Info" field for WordPress users can be used for bios. Array updated with metakey 'description' which has a French version 'description_fr'. Users can't add or modify their own bio. Admin must manually add it in Dashboard. Users on staging with existing EN/FR bios are ID15 and ID79.